### PR TITLE
Remove line-through on filler text for dnf games

### DIFF
--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -79,6 +79,10 @@ tr.dnf * {
   text-decoration: line-through;
 }
 
+tr.dnf td:first-child {
+  text-decoration: none;
+}
+
 a.dnf * {
   text-decoration: line-through;
 }


### PR DESCRIPTION
For dnf games, line-through is applied to the game row in the game overview. This incluedes the usernames of the players, inclueding the commas and spaces between them. This makes the names hard to read. This css removes the line-through on the commas and spaces in the username coloum